### PR TITLE
Prepare for Uint8List SDK breaking change

### DIFF
--- a/flutter_odatabr/lib/src/odata.dart
+++ b/flutter_odatabr/lib/src/odata.dart
@@ -193,12 +193,12 @@ class OData extends _ODataBuilder {
     var statusCode = response.statusCode;
     if (response.statusCode == 200) {
       // done - you should check the response.statusCode
-      String reply = await response.transform(utf8.decoder).join();
+      String reply = await utf8.decoder.bind(response).join();
       //print(reply);
       return reply;
     } else {
       print('response.statusCode: $statusCode');
-      String reply = await response.transform(utf8.decoder).join();
+      String reply = await utf8.decoder.bind(response).join();
       //print(reply);
       return throw (reply);
     }


### PR DESCRIPTION
A recent change to the Dart SDK updated `HttpClientResponse`
to implement `Stream<Uint8List>` rather than implementing
`Stream<List<int>>`.

This forwards-compatible change updates calls to
`Stream.transform(StreamTransformer)` to instead call the
functionally equivalent `StreamTransformer.bind(Stream)`
API, which puts the stream in a covariant position and
thus causes the SDK change to be non-breaking.

https://github.com/dart-lang/sdk/issues/36900
